### PR TITLE
Required boolean validations should accept `false`

### DIFF
--- a/lib/match/rules.js
+++ b/lib/match/rules.js
@@ -18,7 +18,7 @@ module.exports = {
 
 	'required'	: function (x) {
 		// Transform data to work properly with node validator
-		if(!x && x !== 0) x = '';
+		if(!x && x !== 0 && x !== false) x = '';
 		else if(typeof x.toString !== 'undefined') x = x.toString();
 		else x = '' + x;
 

--- a/test/miscellaneousRules.test.js
+++ b/test/miscellaneousRules.test.js
@@ -14,28 +14,28 @@ describe('miscellaneous rules', function() {
 		});
 	});
 
-    describe ('greaterThan/lessThan',function () {
-        it (' should support "greaterThan" rule ', function () {
-            return testRules({
-                greaterThan: 3.5
-            },4,3);
-        });
-        it (' should support "greaterThan" rule ', function () {
-            return testRules({
-                greaterThan: 3.5
-            },3.6,3.5);
-        });
-        it (' should support "lessThan" rule ', function () {
-            return testRules({
-                lessThan: 3.5
-            },3,4);
-        });
-        it (' should support "lessThan" rule ', function () {
-            return testRules({
-                lessThan: 3.5
-            },3.4,3.5);
-        });
+  describe ('greaterThan/lessThan',function () {
+    it (' should support "greaterThan" rule ', function () {
+      return testRules({
+        greaterThan: 3.5
+      }, 4, 3);
     });
+    it (' should support "greaterThan" rule ', function () {
+      return testRules({
+        greaterThan: 3.5
+      }, 3.6, 3.5);
+    });
+    it (' should support "lessThan" rule ', function () {
+      return testRules({
+        lessThan: 3.5
+      }, 3, 4);
+    });
+    it (' should support "lessThan" rule ', function () {
+      return testRules({
+        lessThan: 3.5
+      }, 3.4, 3.5);
+    });
+  });
 
 	describe('url', function () {
 
@@ -55,5 +55,43 @@ describe('miscellaneous rules', function() {
 			},new Date(Date.now() - 100000),new Date(Date.now() + 1000000));
 		});
 	});
+	
+	describe('required', function () {
+	  it(' should support "required" with boolean', function() {
+      testRules({
+        type: 'boolean',
+        required: true
+      }, true, undefined);
+    });
+    
+    it(' should support "required" with integer value 0', function() {
+      testRules({
+        type: 'integer',
+        required: true
+      }, 0, NaN);
+    });
+    
+    it(' should support "required" with string', function() {
+      testRules({
+        type: 'string',
+        required: true
+      }, 'some', '');
+    });
+    
+    it(' should support "required" with empty object', function() {
+      testRules({
+        type: 'json',
+        required: true
+      }, {}, undefined);
+    });
+    
+    it(' should support "required" with array', function() {
+      testRules({
+        type: [],
+        required: true
+      }, ['one'], []);
+    });
+
+  });
 
 });

--- a/test/miscellaneousRules.test.js
+++ b/test/miscellaneousRules.test.js
@@ -64,6 +64,13 @@ describe('miscellaneous rules', function() {
       }, true, undefined);
     });
     
+    it(' should support "required" with boolean value false', function() {
+      testRules({
+        type: 'boolean',
+        required: true
+      }, false, null);
+    });
+    
     it(' should support "required" with integer value 0', function() {
       testRules({
         type: 'integer',


### PR DESCRIPTION
Fixes balderdashy/waterline#671.

When validation is:
``` javascript
{
  type: 'boolean',
  required: true
}
```

Currently only if the field has `true` value will pass this validation rule, when both `true` and `false` values should be accepted. This PR adds support for that.

`null` and `undefined` will still fail.

cc: @kenjinsama, @srjsoftware