### PR TITLE
Extend types through the adapter using dbType

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,16 @@ Anchor.prototype.to = function (ruleset, context) {
 			// Stop at default maxDepth (50) to prevent infinite loops in self-associations
 			errors = errors.concat(Anchor.match.type.call(context, this.data, ruleset['type']));
 		}
+		
+    // Validate a dbType rule
+    else if (rule === 'dbType') {
+      
+      // only if a validation rule exists for it so it doesn't break on an adapter that
+      // doesn't support the particular dbType
+      if(Anchor.prototype.rules[ruleset.dbType]) {
+        errors = errors.concat(Anchor.match.type.call(context, this.data, ruleset.dbType));
+      }
+    }
 
 		// Validate a non-type rule
 		else {

--- a/test/miscellaneousRules.test.js
+++ b/test/miscellaneousRules.test.js
@@ -98,7 +98,22 @@ describe('miscellaneous rules', function() {
         required: true
       }, ['one'], []);
     });
-
+  });
+  
+  describe('dbType', function () {
+    it(' should support "dbType" with existing validation rule', function() {
+      testRules({
+        type: 'float',
+        dbType: 'float'
+      }, 10.9, 'hi');
+    });
+    
+    it(' should support "dbType" with non-existing validation rule', function() {
+      testRules({
+        type: 'float',
+        dbType: 'age'
+      }, 10, 'hi');
+    });
   });
 
 });


### PR DESCRIPTION
This PR is 1 of 2 PRs to address the extension of Custom Types through the adapter - balderdashy/waterline#819. From the model definition perspective the user would use:
```javascript
attributes: {
  spaceDistance: {
    type: "float",
    dbType: "myDbSpecialNumberFormat"
  }
}
```

If the adapter has a validation set for `myDbSpecialNumberFormat`, that should be run otherwise it will only apply the remaining validations for the attribute, in this case `float`. The advantage of such implementation is providing a fallback for adapters that don't implement a given `dbType`.

More details about this in the waterline balderdashy/waterline#981.